### PR TITLE
No quotes for keyframes name

### DIFF
--- a/react-spinner.css
+++ b/react-spinner.css
@@ -19,7 +19,7 @@
   left: -10%;
 }
 
-@keyframes "react-spinner_spin" {
+@keyframes react-spinner_spin {
  0% { opacity: 1; }
  100% { opacity: 0.15; }
 }
@@ -29,7 +29,7 @@
  100% { opacity: 0.15; }
 }
 
-@-webkit-keyframes "react-spinner_spin" {
+@-webkit-keyframes react-spinner_spin {
  0% { opacity: 1; }
  100% { opacity: 0.15; }
 }


### PR DESCRIPTION
This actually makes reworkcss throw (see https://github.com/reworkcss/css/blob/master/lib/parse/index.js#L293)
