### PR TITLE
React v0.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "react-component"
   ],
   "dependencies": {
-    "react": ">=0.10.0"
+    "react": ">=0.12.0"
   },
   "license": "MIT"
 }

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('React');
 var Spinner = require('../');
 

--- a/example/package.json
+++ b/example/package.json
@@ -19,10 +19,10 @@
   "homepage": "https://github.com/chenglou/react-spinner",
   "dependencies": {
     "envify": "^1.2.1",
-    "react": "^0.10.0"
+    "react": "^0.12.0"
   },
   "devDependencies": {
     "browserify": "^4.2.0",
-    "reactify": "^0.13.1"
+    "reactify": "^0.17.1"
   }
 }

--- a/index.jsx
+++ b/index.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 (function(window, React) {
   var Spinner = React.createClass({
     render: function() {
@@ -19,8 +17,8 @@
         );
       }
 
-      return this.transferPropsTo(
-        <div className="react-spinner">{bars}</div>
+      return (
+        <div {...this.props}  className="react-spinner">{bars}</div>
       );
     }
   });

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
   },
   "homepage": "https://github.com/chenglou/react-spinner",
   "dependencies": {
-    "react": ">=0.10.0"
+    "react": ">=0.12.0"
   },
   "example": {
     "script": "example/spin.jsx",
     "style": "react-spinner.css"
   },
   "devDependencies": {
-    "react-tools": "^0.10.0"
+    "react-tools": "^0.12.0"
   }
 }


### PR DESCRIPTION
- transferPropsTo deprecated => use JSX spread instead
- no need for @jsx pragma anymore. React now needs to be exposed. it already was.
