### PR TITLE
Use peerDependencies & change to >=

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "url": "https://github.com/chenglou/react-spinner/issues"
   },
   "homepage": "https://github.com/chenglou/react-spinner",
-  "dependencies": {
-    "react": "^0.12.1"
+  "peerDependencies": {
+    "react": ">=0.12.1"
   },
   "example": {
     "script": "example/spin.jsx",


### PR DESCRIPTION
Using react-spinner in a project using react 0.13.x caused a copy of react 0.12 to be installed for react-spinner to use whilst the top level project continues to use react 0.13.x. This causes the page to fail in very strange ways when react-spinner is imported.

This changes the dependency to use peerDependencies which is designed for plugin-style dependencies such as this, and also relaxes the version restriction to allow any higher version since using '^' would make in incompatible with react 0.13.x (alternative would be having to update the dependency each time react's version was bumped). 