### PR TITLE
Add style attribtue to package.json to allow use of module loaders

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.6",
   "description": "Zero configuration loading spinner.",
   "main": "build/index.js",
+  "style": "react-spinner.css"
   "scripts": {
     "start": "NODE_ENV=development node server.js",
     "compile-example-for-readme": "webpack",


### PR DESCRIPTION
Referencing the css file in package.json allows usage with module loaders like https://github.com/lucasmotta/sass-module-importer