### PR TITLE
Update from `React.createClass` to JavaScript classes

### DIFF
--- a/example/component.jsx
+++ b/example/component.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Spinner from '../index.jsx';
 
-const App = React.createClass({
-  render: function() {
+class App extends React.Component {
+  render() {
     const style = {
       height: 50,
       width: 50,
@@ -14,6 +14,6 @@ const App = React.createClass({
       </div>
     );
   }
-});
+};
 
 export default App;

--- a/index.jsx
+++ b/index.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
-const Spinner = React.createClass({
-  render: function() {
+class Spinner extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
     let bars = [];
     const props = this.props;
 
@@ -24,6 +27,6 @@ const Spinner = React.createClass({
       </div>
     );
   }
-});
+};
 
 export default Spinner;


### PR DESCRIPTION
The usage of `React.createClass` now gives a deprecation warning as of [React v15.5.0](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.createclass) and will be deprecated in v16
I have updated the spinner and example to use [ES6 classes as per React Documentation](https://facebook.github.io/react/docs/components-and-props.html#functional-and-class-components)